### PR TITLE
map 형태 input에도 번들 결과 디렉토리 유지하도록 수정

### DIFF
--- a/packages/pite/src/index.ts
+++ b/packages/pite/src/index.ts
@@ -11,6 +11,12 @@ export interface ViteConfigProps {
     options?: BuildOptions
 }
 
+const replaceExtension = (target: string, replacement: '.mjs' | '.js') => {
+    // .ts .jsx .tsx
+    const regex = /\.([tj]s[x]?)/
+    return target.replace(regex, replacement)
+}
+
 export function createViteConfig({formats, entry, options}: ViteConfigProps) {
     const build: BuildOptions = {
         target: browserslistToEsbuild(),
@@ -24,13 +30,31 @@ export function createViteConfig({formats, entry, options}: ViteConfigProps) {
                 {
                     dir: 'dist/esm',
                     format: 'es',
-                    entryFileNames: '[name].mjs',
+                    entryFileNames: (chunkInfo) => {
+                        const subPath = chunkInfo.facadeModuleId?.split('src')[1]
+
+                        if (subPath) {
+                            const relativePath = subPath.startsWith('/') ? subPath.slice(1) : subPath
+                            return replaceExtension(relativePath, '.mjs')
+                        }
+
+                        return `${chunkInfo.name}.mjs`
+                    },
                     preserveModules: true,
                 },
                 {
                     dir: 'dist/cjs',
                     format: 'cjs',
-                    entryFileNames: '[name].js',
+                    entryFileNames: (chunkInfo) => {
+                        const subPath = chunkInfo.facadeModuleId?.split('src')[1]
+
+                        if (subPath) {
+                            const relativePath = subPath.startsWith('/') ? subPath.slice(1) : subPath
+                            return replaceExtension(relativePath, '.js')
+                        }
+
+                        return `${chunkInfo.name}.js`
+                    },
                     preserveModules: true,
                 },
             ],

--- a/packages/test/vite.config.mjs
+++ b/packages/test/vite.config.mjs
@@ -1,6 +1,5 @@
 import {createViteConfig} from '@naverpay/pite'
 
-// TODO : js, d.ts 간 디렉토리 문제 해결 필요
 export const testInputMap = {
     index: './src/index',
     transpile: './src/utils/transpile',


### PR DESCRIPTION
rollup entryFileNames 콜백함수 직접 정의
src이하의 상대경로 추출, 확장자 replace

## Related Issue <!-- #뒤에 이슈번호 작성 -->

- #1
 
## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- 기존에는 map 형태의 input이 들어오면 다른 디렉토리의 파일들도 /dist 바로 아래에 번들 결과물이 위치하게됨. dts를 사용한 타입 결과물은 디렉토리를 유지하기 때문에 불일치 문제 발생
- entryFileNames 콜백함수를 수정해 js 번들 결과물이 dts처럼 디렉토리 위치를 유지하도록 수정

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
