### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/dark-hornets-make.md
+++ b/.changeset/dark-hornets-make.md
@@ -1,8 +1,0 @@
----
-"@naverpay/pite": patch
-"@naverpay/test": patch
----
-
-.browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다
-
-PR: [.browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다](https://github.com/NaverPayDev/pite/pull/18)

--- a/.changeset/nice-parks-melt.md
+++ b/.changeset/nice-parks-melt.md
@@ -1,8 +1,0 @@
----
-"@naverpay/pite": patch
-"@naverpay/test": patch
----
-
-outDir 옵션을 추가합니다
-
-PR: [outDir 옵션을 추가합니다](https://github.com/NaverPayDev/pite/pull/20)

--- a/packages/pite/CHANGELOG.md
+++ b/packages/pite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @naverpay/pite
 
+## 0.0.4
+
+### Patch Changes
+
+-   bd756c9: .browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다
+
+    PR: [.browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다](https://github.com/NaverPayDev/pite/pull/18)
+
+-   da5c303: outDir 옵션을 추가합니다
+
+    PR: [outDir 옵션을 추가합니다](https://github.com/NaverPayDev/pite/pull/20)
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/pite/package.json
+++ b/packages/pite/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@naverpay/pite",
     "author": "@NaverPayDev/frontend",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "vite 번들러 패키지",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @naverpay/test
 
+## 0.0.3
+
+### Patch Changes
+
+-   bd756c9: .browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다
+
+    PR: [.browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다](https://github.com/NaverPayDev/pite/pull/18)
+
+-   da5c303: outDir 옵션을 추가합니다
+
+    PR: [outDir 옵션을 추가합니다](https://github.com/NaverPayDev/pite/pull/20)
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@naverpay/test",
     "author": "@NaverPayDev/frontend",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "vite 번들러 패키지 테스트",
     "private": true,
     "sideEffects": false,


### PR DESCRIPTION
# Releases
## @naverpay/pite@0.0.4

### Patch Changes

-   bd756c9: .browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다

    PR: [.browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다](https://github.com/NaverPayDev/pite/pull/18)

-   da5c303: outDir 옵션을 추가합니다

    PR: [outDir 옵션을 추가합니다](https://github.com/NaverPayDev/pite/pull/20)

## @naverpay/test@0.0.3

### Patch Changes

-   bd756c9: .browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다

    PR: [.browserslistrc가 없을 때 browserslist에서 발생하는 에러를 해결합니다](https://github.com/NaverPayDev/pite/pull/18)

-   da5c303: outDir 옵션을 추가합니다

    PR: [outDir 옵션을 추가합니다](https://github.com/NaverPayDev/pite/pull/20)
