### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/nasty-deer-sleep.md
+++ b/.changeset/nasty-deer-sleep.md
@@ -1,8 +1,0 @@
----
-"@naverpay/pite": patch
-"@naverpay/test": patch
----
-
-scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다
-
-PR: [scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다](https://github.com/NaverPayDev/pite/pull/31)

--- a/.changeset/rare-jokes-trade.md
+++ b/.changeset/rare-jokes-trade.md
@@ -1,8 +1,0 @@
----
-"@naverpay/pite": patch
-"@naverpay/test": patch
----
-
-TSUP을 사용해 dts를 생성하도록 수정합니다
-
-PR: [TSUP을 사용해 dts를 생성하도록 수정합니다](https://github.com/NaverPayDev/pite/pull/29)

--- a/packages/pite/CHANGELOG.md
+++ b/packages/pite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @naverpay/pite
 
+## 0.0.8
+
+### Patch Changes
+
+-   7d9a5df: scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다
+
+    PR: [scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다](https://github.com/NaverPayDev/pite/pull/31)
+
+-   94ed000: TSUP을 사용해 dts를 생성하도록 수정합니다
+
+    PR: [TSUP을 사용해 dts를 생성하도록 수정합니다](https://github.com/NaverPayDev/pite/pull/29)
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/pite/package.json
+++ b/packages/pite/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@naverpay/pite",
     "author": "@NaverPayDev/frontend",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "vite 번들러 패키지",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @naverpay/test
 
+## 0.0.5
+
+### Patch Changes
+
+-   7d9a5df: scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다
+
+    PR: [scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다](https://github.com/NaverPayDev/pite/pull/31)
+
+-   94ed000: TSUP을 사용해 dts를 생성하도록 수정합니다
+
+    PR: [TSUP을 사용해 dts를 생성하도록 수정합니다](https://github.com/NaverPayDev/pite/pull/29)
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@naverpay/test",
     "author": "@NaverPayDev/frontend",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "vite 번들러 패키지 테스트",
     "private": true,
     "sideEffects": false,


### PR DESCRIPTION
# Releases
## @naverpay/pite@0.0.8

### Patch Changes

-   7d9a5df: scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다

    PR: [scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다](https://github.com/NaverPayDev/pite/pull/31)

-   94ed000: TSUP을 사용해 dts를 생성하도록 수정합니다

    PR: [TSUP을 사용해 dts를 생성하도록 수정합니다](https://github.com/NaverPayDev/pite/pull/29)

## @naverpay/test@0.0.5

### Patch Changes

-   7d9a5df: scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다

    PR: [scss를 단일 css로 묶어서 빌드하는 기능을 추가합니다](https://github.com/NaverPayDev/pite/pull/31)

-   94ed000: TSUP을 사용해 dts를 생성하도록 수정합니다

    PR: [TSUP을 사용해 dts를 생성하도록 수정합니다](https://github.com/NaverPayDev/pite/pull/29)
