### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/olive-heads-invite.md
+++ b/.changeset/olive-heads-invite.md
@@ -1,7 +1,0 @@
----
-"@naverpay/pite": patch
----
-
-[#52] .js, .jsx만 entry에 있는경우 tsup이 수행되지 않도록 막습니다
-
-PR: [[#52] .js, .jsx만 entry에 있는경우 tsup이 수행되지 않도록 막습니다](https://github.com/NaverPayDev/pite/pull/53)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/pite
 
+## 1.1.1
+
+### Patch Changes
+
+-   8366e36: [#52] .js, .jsx만 entry에 있는경우 tsup이 수행되지 않도록 막습니다
+
+    PR: [[#52] .js, .jsx만 entry에 있는경우 tsup이 수행되지 않도록 막습니다](https://github.com/NaverPayDev/pite/pull/53)
+
 ## 1.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@naverpay/pite",
     "author": "@NaverPayDev/frontend",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "A Vite bundler package for libraries",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",


### PR DESCRIPTION
# Releases
## @naverpay/pite@1.1.1

### Patch Changes

-   8366e36: [#52] .js, .jsx만 entry에 있는경우 tsup이 수행되지 않도록 막습니다

    PR: [\[#52\] .js, .jsx만 entry에 있는경우 tsup이 수행되지 않도록 막습니다](https://github.com/NaverPayDev/pite/pull/53)
