### PR TITLE
publint severity 옵션 추가

### DIFF
--- a/.changeset/short-pandas-glow.md
+++ b/.changeset/short-pandas-glow.md
@@ -1,0 +1,5 @@
+---
+'@naverpay/pite': minor
+---
+
+publint severity 옵션 추가

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "dependencies": {
         "@babel/plugin-transform-runtime": "^7.25.9",
         "@naverpay/browserslist-config": "^2.0.0",
-        "@naverpay/publint": "^0.0.5",
+        "@naverpay/publint": "^0.0.6",
         "@rollup/plugin-babel": "^6.0.4",
         "babel-plugin-polyfill-corejs3": "^0.11.0",
         "browserslist": "^4.24.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       '@naverpay/publint':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: ^0.0.6
+        version: 0.0.6
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.0.4(@babel/core@7.26.0)(rollup@4.27.4)
@@ -568,8 +568,8 @@ packages:
     peerDependencies:
       prettier: ^2.8.8 || ^3.0.0
 
-  '@naverpay/publint@0.0.5':
-    resolution: {integrity: sha512-8mv5O+DgC/0YKnMPYqL47ec9/A8ZpjMLOd9KrZ5izLfLPdKAsyGOV0nc136FzZNB4EKtWpmerxulN9buauztow==}
+  '@naverpay/publint@0.0.6':
+    resolution: {integrity: sha512-dqHk6cQhv+2eF7e/sq6QZ7P24pDLXJg0UryYwLE+7gdsijyK6MAvBqplirH01ZOkMpYuMH7KT0E2lC6zK8CDeg==}
     hasBin: true
 
   '@next/eslint-plugin-next@15.0.3':
@@ -3861,7 +3861,7 @@ snapshots:
     dependencies:
       prettier: 3.3.3
 
-  '@naverpay/publint@0.0.5':
+  '@naverpay/publint@0.0.6':
     dependencies:
       meow: 13.2.0
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {BuildOptions, defineConfig, Plugin} from 'vite'
 import {getBrowserslistConfig} from './browserslist'
 import {getExternalDependencies} from './dependencies'
 import {getViteEntry} from './get-vite-entry'
-import publint from './plugins/rollup-plugin-publint'
+import publintPlugin from './plugins/rollup-plugin-publint'
 import {shouldInjectPolyfill} from './polyfill'
 import {isValidBrowserslistConfig, replaceExtension} from './util'
 import vitePluginTsup from './vite-tsup-plugin'
@@ -19,6 +19,7 @@ export interface ViteConfigProps {
     outputs?: {format: 'es' | 'cjs'; dist: string}[]
     cssFileName?: string
     visualize?: boolean | PluginVisualizerOptions
+    publint?: {severity?: 'error' | 'warn' | 'off'}
     /**
      * @description List of polyfills that need to be injected
      */
@@ -39,6 +40,7 @@ export function createViteConfig({
     ],
     cssFileName = 'style.css',
     visualize = false,
+    publint: {severity = 'error'} = {},
     includeRequiredPolyfill = [],
     skipRequiredPolyfillCheck = [],
     options,
@@ -134,7 +136,7 @@ export function createViteConfig({
                 ...inputRollupPlugin,
                 ...(visualize ? [visualizer(typeof visualize === 'object' ? visualize : {})] : []),
                 preserveDirectives(),
-                publint({cwd}),
+                ...(severity !== 'off' ? [publintPlugin({cwd, severity})] : []),
             ],
             ...inputRollupOptions,
         },

--- a/src/plugins/rollup-plugin-publint.ts
+++ b/src/plugins/rollup-plugin-publint.ts
@@ -11,10 +11,9 @@ import {Plugin} from 'vite'
 
 interface PublintOption {
     cwd: string
-    severity: 'error' | 'warn' | 'off'
+    severity: 'error' | 'warn'
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const publint = ({cwd, severity}: PublintOption): Plugin => {
     let hasBuildStartError = false
 
@@ -25,10 +24,15 @@ const publint = ({cwd, severity}: PublintOption): Plugin => {
             try {
                 publintBeforeBuild(cwd)
                 console.log(chalk.green('All good!\n'))
-            } catch {
+            } catch (error) {
+                if (error instanceof Error) {
+                    console.log(
+                        `- [${severity === 'error' ? chalk.red('error') : chalk.yellow('warning')}] ${error.message}`,
+                    )
+                }
                 hasBuildStartError = true
                 console.log('\n')
-                process.exit(1)
+                severity === 'error' && process.exit(1)
             }
         },
         closeBundle: {
@@ -56,12 +60,12 @@ const publint = ({cwd, severity}: PublintOption): Plugin => {
                     }
 
                     console.log(
-                        `- [${hasError ? chalk.red(message.type) : chalk.yellow(message.type)}] ${formatMessage(message, pkg)}`,
+                        `- [${hasError && severity === 'error' ? chalk.red(message.type) : chalk.yellow(message.type)}] ${formatMessage(message, pkg)}`,
                     )
                 }
                 if (hasBuildEndError) {
                     console.log('\n')
-                    process.exit(1)
+                    severity === 'error' && process.exit(1)
                 }
             },
             sequential: true,

--- a/src/plugins/rollup-plugin-publint.ts
+++ b/src/plugins/rollup-plugin-publint.ts
@@ -11,9 +11,11 @@ import {Plugin} from 'vite'
 
 interface PublintOption {
     cwd: string
+    severity: 'error' | 'warn' | 'off'
 }
 
-const publint = ({cwd}: PublintOption): Plugin => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const publint = ({cwd, severity}: PublintOption): Plugin => {
     let hasBuildStartError = false
 
     return {


### PR DESCRIPTION
## Related Issue <!-- #뒤에 이슈번호 작성 -->

- #73 

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

- publint에 severity 옵션을 추가했습니다. (eslint에서 따옴 https://eslint.org/docs/latest/use/configure/rules#rule-severities)
  - error: exit(1) 합니다
  - warn: 잔소리는 하지만 빌드는 해줍니다. 
  - off: publint를 끕니다. 

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
