### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/poor-pets-shave.md
+++ b/.changeset/poor-pets-shave.md
@@ -1,7 +1,0 @@
----
-"@naverpay/pite": patch
----
-
-🔧 Update rollup plugin dependencies to rollup-preserve-directives
-
-PR: [🔧 Update rollup plugin dependencies to rollup-preserve-directives](https://github.com/NaverPayDev/pite/pull/86)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/pite
 
+## 2.2.1
+
+### Patch Changes
+
+-   0812621: 🔧 Update rollup plugin dependencies to rollup-preserve-directives
+
+    PR: [🔧 Update rollup plugin dependencies to rollup-preserve-directives](https://github.com/NaverPayDev/pite/pull/86)
+
 ## 2.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@naverpay/pite",
     "author": "@NaverPayDev/frontend",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "A Vite bundler package for libraries",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",


### PR DESCRIPTION
# Releases
## @naverpay/pite@2.2.1

### Patch Changes

-   0812621: 🔧 Update rollup plugin dependencies to rollup-preserve-directives

    PR: [🔧 Update rollup plugin dependencies to rollup-preserve-directives](https://github.com/NaverPayDev/pite/pull/86)
