### PR TITLE
fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용

### DIFF
--- a/src/plugins/rollup-plugin-publint.ts
+++ b/src/plugins/rollup-plugin-publint.ts
@@ -32,7 +32,9 @@ const publint = ({cwd, severity}: PublintOption): Plugin => {
                 }
                 hasBuildStartError = true
                 console.log('\n')
-                severity === 'error' && process.exit(1)
+                if (severity === 'error') {
+                    this.error(error instanceof Error ? error.message : 'publint check failed before build')
+                }
             }
         },
         closeBundle: {
@@ -65,7 +67,9 @@ const publint = ({cwd, severity}: PublintOption): Plugin => {
                 }
                 if (hasBuildEndError) {
                     console.log('\n')
-                    severity === 'error' && process.exit(1)
+                    if (severity === 'error') {
+                        throw new Error('publint check failed after build')
+                    }
                 }
             },
             sequential: true,


### PR DESCRIPTION
publint 플러그인에서 process.exit(1) 호출 시 프로세스가 즉시 종료되어 다른 플러그인의 에러가 출력되지 않는 문제를 수정합니다.

Closes #89

Generated with [Claude Code](https://claude.ai/code)