### PR TITLE
fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용

### DIFF
--- a/.changeset/lucky-trams-slide.md
+++ b/.changeset/lucky-trams-slide.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/pite": patch
+---
+
+fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용
+
+PR: [fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용](https://github.com/NaverPayDev/pite/pull/97)

--- a/src/plugins/rollup-plugin-publint.ts
+++ b/src/plugins/rollup-plugin-publint.ts
@@ -32,7 +32,9 @@ const publint = ({cwd, severity}: PublintOption): Plugin => {
                 }
                 hasBuildStartError = true
                 console.log('\n')
-                severity === 'error' && process.exit(1)
+                if (severity === 'error') {
+                    this.error(error instanceof Error ? error.message : 'publint check failed before build')
+                }
             }
         },
         closeBundle: {
@@ -65,7 +67,9 @@ const publint = ({cwd, severity}: PublintOption): Plugin => {
                 }
                 if (hasBuildEndError) {
                     console.log('\n')
-                    severity === 'error' && process.exit(1)
+                    if (severity === 'error') {
+                        throw new Error('publint check failed after build')
+                    }
                 }
             },
             sequential: true,


### PR DESCRIPTION
publint 플러그인에서 process.exit(1) 호출 시 프로세스가 즉시 종료되어
다른 플러그인(e.g. preserve-directives)의 에러가 출력되지 않는 문제를 수정합니다.

- buildStart: this.error()를 사용하여 Rollup의 공식 에러 처리 파이프라인을 활용
- closeBundle: throw new Error()를 사용하여 Rollup이 에러를 적절히 처리하도록 변경

외부 인터페이스(publint.severity 옵션)는 변경 없음.

Fixes #89

## Related Issue <!-- #뒤에 이슈번호 작성 -->

-

## Describe your changes <!-- PR의 주요 작업 내용 작성 -->

-

## Request <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용 (참고할 내용) -->

-
