### PR TITLE
fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용

### DIFF
--- a/.changeset/lucky-trams-slide.md
+++ b/.changeset/lucky-trams-slide.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/pite": patch
+---
+
+fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용
+
+PR: [fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용](https://github.com/NaverPayDev/pite/pull/97)

--- a/src/plugins/rollup-plugin-publint.ts
+++ b/src/plugins/rollup-plugin-publint.ts
@@ -32,7 +32,9 @@ const publint = ({cwd, severity}: PublintOption): Plugin => {
                 }
                 hasBuildStartError = true
                 console.log('\n')
-                severity === 'error' && process.exit(1)
+                if (severity === 'error') {
+                    this.error(error instanceof Error ? error.message : 'publint check failed before build')
+                }
             }
         },
         closeBundle: {
@@ -65,7 +67,9 @@ const publint = ({cwd, severity}: PublintOption): Plugin => {
                 }
                 if (hasBuildEndError) {
                     console.log('\n')
-                    severity === 'error' && process.exit(1)
+                    if (severity === 'error') {
+                        throw new Error('publint check failed after build')
+                    }
                 }
             },
             sequential: true,


### PR DESCRIPTION
## 요약

publint 플러그인에서 `process.exit(1)` 호출 시 Node.js 프로세스가 즉시 종료되어, `severity: 'error'`(기본값) 설정 환경에서 다른 플러그인의 에러가 출력되지 않는 문제를 수정합니다.

## 변경 내용

**`buildStart` 훅 (`src/plugins/rollup-plugin-publint.ts`):**

- 변경 전: `severity === 'error' && process.exit(1)`
- 변경 후: `if (severity === 'error') { this.error(...) }` — Rollup 공식 플러그인 에러 API 사용

**`closeBundle` 핸들러 (`src/plugins/rollup-plugin-publint.ts`):**

- 변경 전: `severity === 'error' && process.exit(1)`
- 변경 후: `if (severity === 'error') { throw new Error('publint check failed after build') }` — Rollup이 처리할 수 있도록 에러를 throw

**`.changeset/fix-publint-process-exit.md`:**

- `@naverpay/pite` patch 버전 변경을 위한 changeset 파일 추가

## 개선 효과

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| 에러 처리 방식 | `process.exit(1)` 프로세스 즉시 종료 | Rollup 에러 파이프라인을 통해 처리 |
| 다른 플러그인 에러 노출 | 숨겨짐 (e.g. `preserve-directives` RangeError) | 정상적으로 표시됨 |
| 외부 인터페이스 | — | 변경 없음 (`severity` 옵션 동일) |

Closes #89

Generated with [Claude Code](https://claude.ai/code)