### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/lucky-trams-slide.md
+++ b/.changeset/lucky-trams-slide.md
@@ -1,7 +1,0 @@
----
-"@naverpay/pite": patch
----
-
-fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용
-
-PR: [fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용](https://github.com/NaverPayDev/pite/pull/97)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/pite
 
+## 2.3.1
+
+### Patch Changes
+
+-   e61dc8c: fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용
+
+    PR: [fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용](https://github.com/NaverPayDev/pite/pull/97)
+
 ## 2.3.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@naverpay/pite",
     "author": "@NaverPayDev/frontend",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "A Vite bundler package for libraries",
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",


### PR DESCRIPTION
# Releases
## @naverpay/pite@2.3.1

### Patch Changes

-   e61dc8c: fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용

    PR: [fix: process.exit(1) 대신 Rollup 에러 처리 메커니즘 사용](https://github.com/NaverPayDev/pite/pull/97)
